### PR TITLE
update makefile para retirar ckan key do terminal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ all: clean check sync publish # Limpeza, upload e sincronizacao git
 clean: data/compras-emergenciais-covid-19.csv ## Limpeza data-raw/ para data/
 
 data/compras-emergenciais-covid-19.csv: scripts/clean.R scripts/lib/utils.R data-raw/compras-coronavirus.xlsx data-raw/compras-coronavirus-controle.csv
-	Rscript --verbose $< 2> logs/log.Rout
+	@Rscript --verbose $< 2> logs/log.Rout
 
 build: ## Compilação datapackage.json para buid/
-	Rscript --verbose scripts/build.R 2> logs/log.Rout
+	@Rscript --verbose scripts/build.R 2> logs/log.Rout
 
 sync: ## Stage, commit e push das alterações
 	git add -u
@@ -22,7 +22,7 @@ sync: ## Stage, commit e push das alterações
 	git push origin master
 
 publish: ## Upload data/ para dados.mg.gov.br/
-	Rscript --verbose scripts/publish.R 2> logs/log.Rout
+	@Rscript --verbose scripts/publish.R 2> logs/log.Rout
 
 check: ## Executa conferência
-	Rscript --verbose scripts/check.R 2> logs/log.Rout
+	@Rscript --verbose scripts/check.R 2> logs/log.Rout


### PR DESCRIPTION
@fjuniorr e @Andrelamor, acredito que descobri pq a chave ckan aparece no terminal ao utilizar os recursos criados via makefile. ao iniciar o comando com "@", conforme proposto acima acredito que isso não ocorrerá mais. A referência para tal conclusão foi retirada no artigo "[Makefiles in python projects](https://krzysztofzuraw.com/blog/2016/makefiles-in-python-projects)" quando é dito "There is @ before each echo because by default make prints every line to the console before it's executed. At sign is to suppress this and @ is discarded before line is passed to the shell." Não consegui testar pq não tenho o R instalado na máquina, sendo assim solicito auxílio de vocês. Se quiser podemos fazer o teste juntos!!! Grande abraços!