### PR TITLE
Corrige id do recurso no datapackage.json e define check_upload

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -2,7 +2,7 @@
   "profile": "tabular-data-package",
   "resources": [
     {
-      "id": "43570463-76a2-407e-89f9-4bfd10638354",
+      "id": "72d031e9-2753-469a-acfa-2d67417a2f49",
       "profile": "tabular-data-resource",
       "name": "compras-emergenciais-covid-19",
       "path": "data/compras-emergenciais-covid-19.csv",

--- a/scripts/lib/utils.R
+++ b/scripts/lib/utils.R
@@ -137,3 +137,14 @@ lookup_link_registro_preco <- function(x) {
   
   lookup[x] %>% unname()
 }
+
+check_upload <- function(file, url) {
+  file_hash <- digest::digest(file, file = TRUE)
+  
+  tmp <- tempfile()
+  download.file(url, tmp)
+  url_hash <- digest::digest(tmp, file = TRUE)
+  unlink(tmp)  
+  
+  file_hash == url_hash
+}


### PR DESCRIPTION
A função `check_upload` de fato não estava definida. Copiei a definição do [repo doacoes-covid-19](https://github.com/dados-mg/doacoes-covid-19/blob/19ff38b816c13781003e07450066eca1e29dc9ff/scripts/lib/utils.R#L60).

Além disso, o `id` que estava armazenado no `datapackage.json` não estava de acordo com o `id` do recurso no CKAN.

![Compras_Emergenciais_COVID-19_-_Compras_Emergenciais_COVID-19_-_Portal_de_Dados_Abertos_do_Estado_de_Minas_Gerais](https://user-images.githubusercontent.com/4969445/119558796-3fdb6480-bd78-11eb-8015-6804552c9b79.png)
